### PR TITLE
Fix minor issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 Full support for ANSI colored strings in Julia. Allows formatted output in REPL/Shell
 environment for both Unix and Mac.
 
-##Install
+## Install
 
 ```julia
 Pkg.add("AnsiColor")
 ```
 
-##Using AnsiColor
+## Using AnsiColor
 
 AnsiColor wraps a string in the ANSI escape sequences used for colorized
 text. The style, foreground and backround colors of a string can be set. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ environment for both Unix and Mac.
 ## Install
 
 ```julia
-Pkg.add("AnsiColor")
+import Pkg; Pkg.add("AnsiColor")
 ```
 
 ## Using AnsiColor


### PR DESCRIPTION
This PR updates `README.md` and:
- Fixes the markdown formatting of second-level titles (like `Install`);
- Add `import Pkg;` to the installation command.

It would also be nice to have a `julia>` prompt in front of commands, emulating REPL. This seems to be in accordance with many packages in the Julia ecosystem.